### PR TITLE
feat: Streamline configuration management with interactive and flag-based options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+// File: README.md
 # Execute My Will
 
 A CLI application that interprets natural language intents and executes appropriate system commands with your permission.
@@ -11,7 +12,7 @@ A CLI application that interprets natural language intents and executes appropri
 - Safe command confirmation
 - Alias and environment awareness
 - Cross-platform support (Linux focus)
-- Flexible configuration with Cobra/Viper
+- Simple configuration management
 
 ## Installation
 
@@ -19,16 +20,53 @@ A CLI application that interprets natural language intents and executes appropri
 go build -o execute-my-will cmd/execute-my-will/main.go
 ```
 
+## Quick Start
+
+1. **Configure the application** (required on first run):
+   ```bash
+   ./execute-my-will configure
+   ```
+   
+   This will start an interactive configuration session where you'll set:
+   - AI Provider (gemini, openai, anthropic)
+   - API Key (required)
+   - Model (uses defaults if not specified)
+   - Max Tokens (default: 1000)
+   - Temperature (default: 0.1)
+
+2. **Use the application**:
+   ```bash
+   ./execute-my-will "list all the contents of my home directory"
+   ```
+
 ## Configuration
 
-The application supports multiple configuration methods:
+### Interactive Configuration
+Run the configure command without any flags for an interactive setup:
 
-### 1. Command Line Flags
 ```bash
-./execute-my-will --api-key "your-key" --provider gemini "list my files"
+./execute-my-will configure
 ```
 
-### 2. Config File (`~/.execute-my-will.yaml`)
+You'll be prompted for each setting with default values shown in brackets. Press Enter to accept defaults.
+
+### Non-Interactive Configuration
+Set specific configuration values using flags:
+
+```bash
+# Set a single value
+./execute-my-will configure --api-key "your-api-key-here"
+
+# Set multiple values
+./execute-my-will configure --provider openai --api-key "sk-xxx" --model "gpt-4"
+
+# Update temperature setting
+./execute-my-will configure --temperature 0.2
+```
+
+### Configuration File
+The configuration is stored in `~/.execute-my-will.yaml`:
+
 ```yaml
 ai:
   provider: gemini
@@ -38,75 +76,69 @@ ai:
   temperature: 0.1
 ```
 
-### 3. Environment Variables
+## Usage Examples
+
 ```bash
-export EXECUTE_MY_WILL_API_KEY="your-api-key"
-export EXECUTE_MY_WILL_PROVIDER="gemini"
+# Basic file operations
 ./execute-my-will "list my files"
-```
+./execute-my-will "copy file.txt to backup directory"
 
-### Configuration Priority
-1. Command line flags (highest priority)
-2. Environment variables
-3. Config file
-4. Default values (lowest priority)
+# System operations  
+./execute-my-will "add /usr/local/bin to my PATH permanently"
+./execute-my-will "install docker"
 
-## Usage
+# Archive operations
+./execute-my-will "extract archive.zip to current directory"
 
-```bash
-# Basic usage
-./execute-my-will "list all the contents of my home directory"
-
-# With flags
-./execute-my-will --provider openai --api-key sk-xxx "add /python3/ to my path"
-
-# Using custom config file
-./execute-my-will --config /path/to/config.yaml "extract zip file"
-
-# View help
-./execute-my-will --help
-```
-
-## Available Flags
-
-- `--config`: Custom config file path
-- `--provider`: AI provider (gemini, openai, anthropic)
-- `--api-key`: API key for the provider
-- `--model`: Model to use (uses provider defaults if not specified)
-- `--max-tokens`: Maximum tokens for response (default: 1000)
-- `--temperature`: AI temperature setting (default: 0.1)
-
-## Configuration Examples
-
-### Gemini (Google)
-```yaml
-ai:
-  provider: gemini
-  api_key: your-gemini-key
-  model: gemini-pro
-```
-
-### OpenAI
-```yaml
-ai:
-  provider: openai
-  api_key: sk-your-openai-key
-  model: gpt-4
-```
-
-### Anthropic
-```yaml
-ai:
-  provider: anthropic
-  api_key: your-anthropic-key
-  model: claude-3-sonnet-20240229
+# View current configuration
+./execute-my-will configure --help
 ```
 
 ## Safety Features
 
-- Command confirmation before execution
-- Directory existence validation
-- System capability analysis
-- Safe command generation
+- **Configuration validation**: Ensures all required settings are present
+- **Command confirmation**: Always asks before executing commands
+- **Directory validation**: Checks that referenced directories exist
+- **System analysis**: Understands your shell, aliases, and available commands
+- **Safe command generation**: AI is instructed to generate safe, non-destructive commands
+
+## Configuration Commands
+
+| Command | Description |
+|---------|-------------|
+| `configure` | Interactive configuration setup |
+| `configure --api-key KEY` | Set API key |
+| `configure --provider PROVIDER` | Set AI provider (gemini/openai/anthropic) |
+| `configure --model MODEL` | Set model name |
+| `configure --max-tokens N` | Set maximum tokens |
+| `configure --temperature N` | Set temperature (0.0-1.0) |
+
+## Supported AI Providers
+
+### Gemini (Google)
+```bash
+./execute-my-will configure --provider gemini --api-key your-gemini-key
+```
+Default model: `gemini-pro`
+
+### OpenAI (Coming Soon)
+```bash
+./execute-my-will configure --provider openai --api-key sk-your-openai-key
+```
+Default model: `gpt-3.5-turbo`
+
+### Anthropic (Coming Soon)  
+```bash
+./execute-my-will configure --provider anthropic --api-key your-anthropic-key
+```
+Default model: `claude-3-sonnet-20240229`
 
 Your faithful digital knight awaits your commands! ⚔️
+
+## Troubleshooting
+
+**Configuration not found**: If you see a message about configuration not found, run `./execute-my-will configure` to set up your configuration.
+
+**API key issues**: Make sure your API key is valid and has the necessary permissions for your chosen AI provider.
+
+**Command validation errors**: The application validates directory references and command safety. Make sure referenced paths exist and are accessible.

--- a/cmd/execute-my-will/main.go
+++ b/cmd/execute-my-will/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		log.Printf("Noble quest has failed: %v", err)
+		log.Printf("Noble quest has failed!")
 		os.Exit(1)
 	}
 }

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -1,3 +1,4 @@
+// File: internal/ai/anthropic.go
 package ai
 
 import (
@@ -8,14 +9,18 @@ import (
 
 // Anthropic Provider (placeholder)
 type AnthropicProvider struct {
-	apiKey string
-	model  string
+	apiKey      string
+	model       string
+	maxTokens   int
+	temperature float32
 }
 
 func NewAnthropicProvider(cfg *config.Config) (*AnthropicProvider, error) {
 	return &AnthropicProvider{
-		apiKey: cfg.APIKey,
-		model:  cfg.Model,
+		apiKey:      cfg.APIKey,
+		model:       cfg.Model,
+		maxTokens:   cfg.MaxTokens,
+		temperature: cfg.Temperature,
 	}, nil
 }
 

--- a/internal/ai/gemini.go
+++ b/internal/ai/gemini.go
@@ -1,3 +1,4 @@
+// File: internal/ai/gemini.go
 package ai
 
 import (
@@ -12,9 +13,10 @@ import (
 
 // Gemini Provider
 type GeminiProvider struct {
-	apiKey    string
-	model     string
-	maxTokens int
+	apiKey      string
+	model       string
+	maxTokens   int
+	temperature float32
 }
 
 type GeminiRequest struct {
@@ -45,9 +47,10 @@ type GeminiCandidate struct {
 
 func NewGeminiProvider(cfg *config.Config) (*GeminiProvider, error) {
 	return &GeminiProvider{
-		apiKey:    cfg.APIKey,
-		model:     cfg.Model,
-		maxTokens: cfg.MaxTokens,
+		apiKey:      cfg.APIKey,
+		model:       cfg.Model,
+		maxTokens:   cfg.MaxTokens,
+		temperature: cfg.Temperature,
 	}, nil
 }
 
@@ -64,7 +67,7 @@ func (g *GeminiProvider) GenerateResponse(prompt string) (string, error) {
 		},
 		GenerationConfig: GeminiGenerationConfig{
 			MaxOutputTokens: g.maxTokens,
-			Temperature:     0.1,
+			Temperature:     g.temperature,
 		},
 	}
 

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -8,14 +8,18 @@ import (
 
 // OpenAI Provider (placeholder)
 type OpenAIProvider struct {
-	apiKey string
-	model  string
+	apiKey      string
+	model       string
+	maxTokens   int
+	temperature float32
 }
 
 func NewOpenAIProvider(cfg *config.Config) (*OpenAIProvider, error) {
 	return &OpenAIProvider{
-		apiKey: cfg.APIKey,
-		model:  cfg.Model,
+		apiKey:      cfg.APIKey,
+		model:       cfg.Model,
+		maxTokens:   cfg.MaxTokens,
+		temperature: cfg.Temperature,
 	}, nil
 }
 

--- a/internal/cli/configure.go
+++ b/internal/cli/configure.go
@@ -1,0 +1,220 @@
+// File: internal/cli/configure.go
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/minand-mohan/execute-my-will/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var configureCmd = &cobra.Command{
+	Use:   "configure",
+	Short: "Configure your digital knight's settings",
+	Long:  "Set up or modify the configuration for your faithful digital assistant.",
+	RunE:  runConfigure,
+}
+
+func init() {
+	// Add flags for non-interactive configuration
+	configureCmd.Flags().String("provider", "", "AI provider (gemini, openai, anthropic)")
+	configureCmd.Flags().String("api-key", "", "API key for the AI provider")
+	configureCmd.Flags().String("model", "", "Model to use (uses provider defaults if not specified)")
+	configureCmd.Flags().Int("max-tokens", 0, "Maximum tokens for AI response")
+	configureCmd.Flags().Float32("temperature", -1, "Temperature for AI response (0.0-1.0)")
+}
+
+func runConfigure(cmd *cobra.Command, args []string) error {
+	fmt.Println("🔧 Configuring your digital knight...")
+	fmt.Println()
+
+	// Check if any flags were provided for non-interactive mode
+	hasFlags := cmd.Flags().Changed("provider") ||
+		cmd.Flags().Changed("api-key") ||
+		cmd.Flags().Changed("model") ||
+		cmd.Flags().Changed("max-tokens") ||
+		cmd.Flags().Changed("temperature")
+
+	// Load existing config or create new one
+	cfg, err := config.Load()
+	if err != nil && !config.IsConfigNotFound(err) {
+		return fmt.Errorf("failed to load existing configuration: %w", err)
+	}
+	if cfg == nil {
+		cfg = config.New()
+	}
+
+	if hasFlags {
+		// Non-interactive mode: update specific values from flags
+		if cmd.Flags().Changed("provider") {
+			provider, _ := cmd.Flags().GetString("provider")
+			cfg.AIProvider = provider
+		}
+
+		if cmd.Flags().Changed("api-key") {
+			apiKey, _ := cmd.Flags().GetString("api-key")
+			cfg.APIKey = apiKey
+		}
+
+		if cmd.Flags().Changed("model") {
+			model, _ := cmd.Flags().GetString("model")
+			cfg.Model = model
+		}
+
+		if cmd.Flags().Changed("max-tokens") {
+			maxTokens, _ := cmd.Flags().GetInt("max-tokens")
+			cfg.MaxTokens = maxTokens
+		}
+
+		if cmd.Flags().Changed("temperature") {
+			temperature, _ := cmd.Flags().GetFloat32("temperature")
+			cfg.Temperature = temperature
+		}
+
+		fmt.Println("📝 Updating configuration with provided values...")
+	} else {
+		// Interactive mode
+		fmt.Println("⚙️  Interactive configuration mode")
+		fmt.Println("📋 Press Enter to use default values shown in [brackets]")
+		fmt.Println()
+
+		if err := runInteractiveConfiguration(cfg); err != nil {
+			return fmt.Errorf("interactive configuration failed: %w", err)
+		}
+	}
+
+	// Validate configuration
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("configuration validation failed: %w", err)
+	}
+
+	// Save configuration
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	// Display final configuration
+	fmt.Println()
+	fmt.Println("✅ Configuration saved successfully!")
+	fmt.Println()
+	displayConfiguration(cfg)
+
+	return nil
+}
+
+func runInteractiveConfiguration(cfg *config.Config) error {
+	reader := bufio.NewReader(os.Stdin)
+
+	// Configure AI Provider
+	fmt.Printf("🤖 AI Provider [%s]: ", cfg.AIProvider)
+	if input := readInput(reader); input != "" {
+		cfg.AIProvider = input
+	}
+
+	// Update model default based on provider
+	if cfg.Model == "" || !isValidModelForProvider(cfg.Model, cfg.AIProvider) {
+		cfg.Model = config.GetDefaultModel(cfg.AIProvider)
+	}
+
+	// Configure API Key (mandatory)
+	for {
+		fmt.Printf("🔑 API Key [%s]: ", maskAPIKey(cfg.APIKey))
+		if input := readInput(reader); input != "" {
+			cfg.APIKey = input
+			break
+		} else if cfg.APIKey != "" {
+			// Keep existing API key
+			break
+		}
+		fmt.Println("❌ API Key is required. Please provide a valid API key.")
+	}
+
+	// Configure Model
+	fmt.Printf("🧠 Model [%s]: ", cfg.Model)
+	if input := readInput(reader); input != "" {
+		cfg.Model = input
+	}
+
+	// Configure Max Tokens
+	fmt.Printf("📊 Max Tokens [%d]: ", cfg.MaxTokens)
+	if input := readInput(reader); input != "" {
+		if tokens, err := parseIntInput(input); err == nil {
+			cfg.MaxTokens = tokens
+		} else {
+			fmt.Printf("⚠️  Invalid number format, using default: %d\n", cfg.MaxTokens)
+		}
+	}
+
+	// Configure Temperature
+	fmt.Printf("🌡️  Temperature [%.1f]: ", cfg.Temperature)
+	if input := readInput(reader); input != "" {
+		if temp, err := parseFloatInput(input); err == nil && temp >= 0.0 && temp <= 1.0 {
+			cfg.Temperature = temp
+		} else {
+			fmt.Printf("⚠️  Invalid temperature (must be 0.0-1.0), using default: %.1f\n", cfg.Temperature)
+		}
+	}
+
+	return nil
+}
+
+func readInput(reader *bufio.Reader) string {
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(input)
+}
+
+func parseIntInput(input string) (int, error) {
+	var result int
+	_, err := fmt.Sscanf(input, "%d", &result)
+	return result, err
+}
+
+func parseFloatInput(input string) (float32, error) {
+	var result float32
+	_, err := fmt.Sscanf(input, "%f", &result)
+	return result, err
+}
+
+func maskAPIKey(apiKey string) string {
+	if apiKey == "" {
+		return "not set"
+	}
+	if len(apiKey) <= 8 {
+		return strings.Repeat("*", len(apiKey))
+	}
+	return apiKey[:4] + strings.Repeat("*", len(apiKey)-8) + apiKey[len(apiKey)-4:]
+}
+
+func isValidModelForProvider(model, provider string) bool {
+	// Simple validation - can be expanded
+	switch provider {
+	case "gemini":
+		return strings.HasPrefix(model, "gemini")
+	case "openai":
+		return strings.HasPrefix(model, "gpt") || strings.HasPrefix(model, "text-")
+	case "anthropic":
+		return strings.HasPrefix(model, "claude")
+	default:
+		return true
+	}
+}
+
+func displayConfiguration(cfg *config.Config) {
+	fmt.Println("📋 Current Configuration:")
+	fmt.Println("┌─────────────────────────────────────────┐")
+	fmt.Printf("│ Provider:     %-25s │\n", cfg.AIProvider)
+	fmt.Printf("│ API Key:      %-25s │\n", maskAPIKey(cfg.APIKey))
+	fmt.Printf("│ Model:        %-25s │\n", cfg.Model)
+	fmt.Printf("│ Max Tokens:   %-25d │\n", cfg.MaxTokens)
+	fmt.Printf("│ Temperature:  %-25.1f │\n", cfg.Temperature)
+	fmt.Println("└─────────────────────────────────────────┘")
+	fmt.Println()
+	fmt.Println("🎯 Your knight is now ready to serve!")
+	fmt.Println("💡 Try: execute-my-will \"list my files\"")
+}


### PR DESCRIPTION
This commit introduces a streamlined configuration management system, replacing the previous Viper-based approach with a simpler, more user-friendly method:

- Replaced Viper with direct YAML file reading and writing for configuration storage in `internal/config/config.go`.
- Added `internal/cli/configure.go` to implement an interactive configuration command, guiding users through setting up their AI provider, API key, model, and other settings.
- Implemented non-interactive configuration via flags for the `configure` command, allowing users to set specific configuration values directly from the command line.
- Updated `internal/cli/root.go` to remove Viper-related code and integrate the new `configure` command. The root command now checks for the existence of the configuration file and prompts the user to configure the application if it's missing.
- Modified AI provider implementations (`internal/ai/gemini.go`, `internal/ai/openai.go`, `internal/ai/anthropic.go`) to accept `maxTokens` and `temperature` from the configuration.
- Updated `README.md` to reflect the new configuration process, including instructions for both interactive and flag-based configuration, and updated usage examples.