### PR TITLE
feat: Disable default Cobra completion command

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,6 +19,9 @@ var rootCmd = &cobra.Command{
 	Long:  "A CLI application that interprets your natural language intent and executes the appropriate system commands with your permission, my lord.",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  executeWill,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
 }
 
 func Execute() error {


### PR DESCRIPTION
This commit disables the default Cobra completion command to prevent conflicts with custom completion logic.

- Added `CompletionOptions{DisableDefaultCmd: true}` to the root command definition in `internal/cli/root.go`. This disables the default `completion` subcommand provided by Cobra, ensuring that only custom completion logic is used.