### PR TITLE
feat: Introduce execution modes and command explanation functionality

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Model       string  `yaml:"model"`
 	MaxTokens   int     `yaml:"max_tokens"`
 	Temperature float32 `yaml:"temperature"`
+	Mode        string  `yaml:"mode"` // field for monarch/royal-heir modes
 }
 
 type ConfigFile struct {
@@ -28,6 +29,7 @@ func New() *Config {
 		Model:       "gemini-pro",
 		MaxTokens:   1000,
 		Temperature: 0.1,
+		Mode:        "", // Empty by default, requires configuration
 	}
 }
 
@@ -86,6 +88,14 @@ func Save(cfg *Config) error {
 func (c *Config) Validate() error {
 	if c.APIKey == "" {
 		return fmt.Errorf("API key is required. Run 'execute-my-will configure' to set it up")
+	}
+
+	if c.Mode == "" {
+		return fmt.Errorf("mode is required. I must know who I serve. Run 'execute-my-will configure' to set your preferred mode (monarch or royal-heir)")
+	}
+
+	if c.Mode != "monarch" && c.Mode != "royal-heir" {
+		return fmt.Errorf("invalid mode '%s'. I only serve the 'monarch' or the 'royal-heir'", c.Mode)
 	}
 
 	if c.AIProvider == "" {


### PR DESCRIPTION
This commit introduces the concept of execution modes ('monarch' and 'royal-heir') to control the verbosity of command explanations, along with the functionality to explain generated commands.

- Added a `Mode` field to the `Config` struct in `internal/config/config.go` to store the execution mode. The mode can be configured via the `configure` command or a command-line flag. Validation is added to ensure the mode is either 'monarch' or 'royal-heir'.
- Implemented the `ExplainCommand` method in `internal/ai/client.go` and corresponding `buildExplanationPrompt` to generate explanations for commands using the AI provider.
- Modified `internal/cli/root.go` to check the configured mode. If the mode is 'royal-heir', the generated command is explained to the user before execution.
- Added a `--mode` flag to the root command and configure command in `internal/cli/root.go` and `internal/cli/configure.go` respectively, allowing users to specify the execution mode.
- Updated the interactive configuration in `internal/cli/configure.go` to allow users to select their preferred execution mode.