### PR TITLE
Add Environment Command Validation to Prevent Ineffective Shell Operations

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -113,6 +113,17 @@ func executeWill(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Validate if the command affects the environment
+	envValidator := system.NewEnvironmentValidator(sysInfo)
+	if err := envValidator.ValidateEnvironmentCommand(command); err != nil {
+		if envErr, ok := err.(*system.EnvironmentCommandError); ok {
+			fmt.Println()
+			fmt.Println(envErr.GetKnightlyMessage())
+			return nil
+		}
+		return fmt.Errorf("environment validation failed: %w", err)
+	}
+
 	// Ask for confirmation
 	if cfg.Mode == "monarch" {
 		fmt.Print("🤴 Do you wish me to proceed with this quest? (y/N): ")

--- a/internal/system/env_validator.go
+++ b/internal/system/env_validator.go
@@ -1,0 +1,454 @@
+// File: internal/system/env_validator.go
+package system
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type EnvironmentValidator struct {
+	sysInfo *Info
+}
+
+func NewEnvironmentValidator(sysInfo *Info) *EnvironmentValidator {
+	return &EnvironmentValidator{sysInfo: sysInfo}
+}
+
+// ValidateEnvironmentCommand checks if a command would affect the parent shell environment
+// and returns an error with the command if it would be ineffective in a subshell
+func (ev *EnvironmentValidator) ValidateEnvironmentCommand(command string) error {
+	// Clean the command for analysis
+	cleanCmd := strings.TrimSpace(command)
+	if cleanCmd == "" {
+		return nil
+	}
+
+	// Check for environment-affecting patterns
+	if envCmd := ev.detectEnvironmentCommand(cleanCmd); envCmd != "" {
+		return &EnvironmentCommandError{
+			Command:     command,
+			Reason:      envCmd,
+			Explanation: "this application cannot modify your terminal session",
+		}
+	}
+
+	return nil
+}
+
+// detectEnvironmentCommand analyzes the command and returns the type of environment command detected
+func (ev *EnvironmentValidator) detectEnvironmentCommand(command string) string {
+	// Convert to lowercase for case-insensitive matching
+	lowerCmd := strings.ToLower(command)
+
+	// Remove leading sudo, && chains, and pipes for core command analysis
+	coreCmd := ev.extractCoreCommand(lowerCmd)
+
+	// Check for different types of environment-affecting commands
+	checks := []struct {
+		name     string
+		detector func(string, string) bool
+	}{
+		{"path_modification", ev.detectPathModification}, // Check path_modification before export
+		{"conda_env", ev.detectCondaEnvironment},         // Check conda before virtual_env
+		{"source", ev.detectSourceCommand},
+		{"export", ev.detectExportCommand},
+		{"alias", ev.detectAliasCommand},
+		{"cd", ev.detectCdCommand},
+		{"virtual_env", ev.detectVirtualEnvCommand},
+		{"shell_function", ev.detectShellFunctionCommand},
+		{"environment_module", ev.detectEnvironmentModuleCommand},
+		{"shell_options", ev.detectShellOptions},
+		{"docker_env", ev.detectDockerEnvironment},
+		{"rbenv_pyenv", ev.detectVersionManagers},
+	}
+
+	for _, check := range checks {
+		if check.detector(coreCmd, command) {
+			return check.name
+		}
+	}
+
+	return ""
+}
+
+// extractCoreCommand removes common prefixes and extracts the main command
+func (ev *EnvironmentValidator) extractCoreCommand(command string) string {
+	// Remove sudo and common prefixes
+	prefixes := []string{"sudo ", "sudo -E ", "sudo -i ", "nohup "}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(command, prefix) {
+			command = strings.TrimPrefix(command, prefix)
+			break
+		}
+	}
+
+	// Handle command chaining - analyze the first significant command
+	// Split by && and || and ; to get individual commands
+	separators := []string{" && ", " || ", " ; ", "; "}
+	for _, sep := range separators {
+		if strings.Contains(command, sep) {
+			parts := strings.Split(command, sep)
+			// Find the first non-install command
+			for _, part := range parts {
+				trimmed := strings.TrimSpace(part)
+				if trimmed != "" && !ev.isInstallCommand(trimmed) {
+					command = trimmed
+					break
+				}
+			}
+			break
+		}
+	}
+
+	return strings.TrimSpace(command)
+}
+
+// isInstallCommand checks if the command is an installation command (these are OK to run in subshell)
+func (ev *EnvironmentValidator) isInstallCommand(command string) bool {
+	installPatterns := []string{
+		"apt update", "apt upgrade", "apt install", "apt-get update", "apt-get upgrade", "apt-get install",
+		"yum install", "yum update", "dnf install", "dnf update",
+		"pacman -S", "pacman -Sy", "pacman -Syu",
+		"brew install", "brew update", "brew upgrade",
+		"pip install", "pip3 install",
+		"npm install", "npm update",
+		"gem install", "cargo install", "go install", "snap install",
+	}
+
+	// Remove sudo prefix for checking
+	cleanCmd := command
+	if strings.HasPrefix(cleanCmd, "sudo ") {
+		cleanCmd = strings.TrimPrefix(cleanCmd, "sudo ")
+	}
+	cleanCmd = strings.TrimSpace(cleanCmd)
+
+	for _, pattern := range installPatterns {
+		if strings.HasPrefix(cleanCmd, pattern) {
+			return true
+		}
+	}
+
+	// Also check for common install command patterns with flags
+	installWithFlagsPatterns := []string{
+		"apt install -", "apt-get install -",
+		"yum install -", "dnf install -",
+		"brew install -",
+	}
+
+	for _, pattern := range installWithFlagsPatterns {
+		if strings.HasPrefix(cleanCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Specific detectors for different types of environment commands
+
+func (ev *EnvironmentValidator) detectSourceCommand(coreCmd, fullCmd string) bool {
+	sourcePatterns := []string{
+		"source ",
+		". ", // dot command is equivalent to source
+	}
+
+	for _, pattern := range sourcePatterns {
+		if strings.HasPrefix(coreCmd, pattern) {
+			// Make sure it's not just ". " followed by a command
+			remaining := strings.TrimPrefix(coreCmd, pattern)
+			remaining = strings.TrimSpace(remaining)
+
+			// Check if it looks like a file (has extension or known config files)
+			if ev.looksLikeSourceableFile(remaining) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectExportCommand(coreCmd, fullCmd string) bool {
+	// Direct export commands
+	if strings.HasPrefix(coreCmd, "export ") {
+		return true
+	}
+
+	// Pattern: VAR=value (without export keyword) - check for uppercase variable names
+	// Need to check against the original case since coreCmd is lowercased
+	varAssignPattern := regexp.MustCompile(`^[A-Z_][A-Z0-9_]*=`)
+	if varAssignPattern.MatchString(strings.TrimSpace(fullCmd)) {
+		return true
+	}
+
+	// Check for PATH modifications in various forms
+	pathPatterns := []string{
+		"path=", "PATH=",
+		"$path", "$PATH",
+	}
+
+	for _, pattern := range pathPatterns {
+		if strings.Contains(fullCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectAliasCommand(coreCmd, fullCmd string) bool {
+	return strings.HasPrefix(coreCmd, "alias ") || strings.HasPrefix(coreCmd, "unalias ")
+}
+
+func (ev *EnvironmentValidator) detectCdCommand(coreCmd, fullCmd string) bool {
+	// Basic cd command
+	if strings.HasPrefix(coreCmd, "cd ") || coreCmd == "cd" {
+		return true
+	}
+
+	// pushd/popd commands
+	if strings.HasPrefix(coreCmd, "pushd ") || strings.HasPrefix(coreCmd, "popd") {
+		return true
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectVirtualEnvCommand(coreCmd, fullCmd string) bool {
+	venvPatterns := []string{
+		// Python virtual environments
+		"activate",
+		"deactivate",
+		"workon ",
+		"mkvirtualenv ",
+		"rmvirtualenv ",
+		"virtualenv",
+		"python -m venv",
+		"python3 -m venv",
+
+		// Poetry
+		"poetry shell",
+		"poetry env",
+
+		// Pipenv
+		"pipenv shell",
+		"pipenv activate",
+	}
+
+	for _, pattern := range venvPatterns {
+		if strings.HasPrefix(coreCmd, pattern) || strings.Contains(coreCmd, pattern) {
+			return true
+		}
+	}
+
+	// Check for activation scripts
+	if strings.Contains(fullCmd, "bin/activate") || strings.Contains(fullCmd, "Scripts/activate") {
+		return true
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectShellFunctionCommand(coreCmd, fullCmd string) bool {
+	// Function definition patterns
+	functionPatterns := []string{
+		"function ",
+		"() {",
+	}
+
+	for _, pattern := range functionPatterns {
+		if strings.Contains(fullCmd, pattern) {
+			return true
+		}
+	}
+
+	// Check for function calls that modify environment
+	if strings.HasPrefix(coreCmd, "unset ") {
+		return true
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectEnvironmentModuleCommand(coreCmd, fullCmd string) bool {
+	modulePatterns := []string{
+		"module load",
+		"module unload",
+		"module purge",
+		"module swap",
+		"ml ", // short form of module command
+	}
+
+	for _, pattern := range modulePatterns {
+		if strings.HasPrefix(coreCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectPathModification(coreCmd, fullCmd string) bool {
+	// Look for PATH modifications that aren't exports - check the full command
+	pathModPatterns := []string{
+		">> ~/.bashrc",
+		">> ~/.zshrc",
+		">> ~/.profile",
+		">> ~/.bash_profile",
+		">> $HOME/.bashrc",
+		">> $HOME/.zshrc",
+	}
+
+	for _, pattern := range pathModPatterns {
+		if strings.Contains(fullCmd, pattern) {
+			// Also check that it contains PATH or export to be sure it's path modification
+			if strings.Contains(fullCmd, "PATH") || strings.Contains(fullCmd, "export") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectShellOptions(coreCmd, fullCmd string) bool {
+	shellOptPatterns := []string{
+		"set -", "set +",
+		"shopt -s", "shopt -u",
+		"setopt", "unsetopt",
+		"ulimit",
+		"umask",
+	}
+
+	for _, pattern := range shellOptPatterns {
+		if strings.HasPrefix(coreCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectCondaEnvironment(coreCmd, fullCmd string) bool {
+	condaPatterns := []string{
+		"conda activate",
+		"conda deactivate",
+		"conda env",
+		"mamba activate",
+		"mamba deactivate",
+	}
+
+	for _, pattern := range condaPatterns {
+		if strings.HasPrefix(coreCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectDockerEnvironment(coreCmd, fullCmd string) bool {
+	dockerEnvPatterns := []string{
+		"eval $(docker-machine env",
+		"docker-machine env",
+		"$(aws ecr get-login",
+		"eval $(aws ecr get-login",
+	}
+
+	for _, pattern := range dockerEnvPatterns {
+		if strings.Contains(fullCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) detectVersionManagers(coreCmd, fullCmd string) bool {
+	versionMgrPatterns := []string{
+		// rbenv
+		"rbenv shell",
+		"rbenv local",
+		"rbenv global",
+
+		// pyenv
+		"pyenv shell",
+		"pyenv local",
+		"pyenv global",
+
+		// nvm
+		"nvm use",
+		"nvm alias",
+
+		// nodenv
+		"nodenv shell",
+		"nodenv local",
+		"nodenv global",
+
+		// jenv
+		"jenv shell",
+		"jenv local",
+		"jenv global",
+
+		// tfenv
+		"tfenv use",
+	}
+
+	for _, pattern := range versionMgrPatterns {
+		if strings.HasPrefix(coreCmd, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ev *EnvironmentValidator) looksLikeSourceableFile(filename string) bool {
+	// Common sourceable file patterns
+	sourceablePatterns := []string{
+		".bashrc", ".zshrc", ".profile", ".bash_profile",
+		".env", ".envrc",
+		"activate", // virtualenv activation
+		".sh", ".bash", ".zsh",
+	}
+
+	filename = strings.ToLower(filename)
+
+	// Check for exact matches or file extensions
+	for _, pattern := range sourceablePatterns {
+		if strings.Contains(filename, pattern) {
+			return true
+		}
+	}
+
+	// Check for environment variable files
+	if strings.Contains(filename, "env") && (strings.HasSuffix(filename, ".txt") ||
+		strings.HasSuffix(filename, ".conf") || !strings.Contains(filename, ".")) {
+		return true
+	}
+
+	return false
+}
+
+// EnvironmentCommandError represents an error for environment-affecting commands
+type EnvironmentCommandError struct {
+	Command     string
+	Reason      string
+	Explanation string
+}
+
+func (e *EnvironmentCommandError) Error() string {
+	return fmt.Sprintf("environment command detected: %s", e.Reason)
+}
+
+func (e *EnvironmentCommandError) GetKnightlyMessage() string {
+	return fmt.Sprintf(`🏰 I cannot change the realm's environment for you, sire, as %s.
+
+⚔️  However, here is the command you should execute in your own noble shell:
+
+    %s
+
+🛡️  Execute this command directly in your terminal to affect your current environment.`,
+		e.Explanation, e.Command)
+}

--- a/internal/system/env_validator_test.go
+++ b/internal/system/env_validator_test.go
@@ -1,0 +1,357 @@
+// File: internal/system/env_validator_test.go
+package system
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnvironmentValidator(t *testing.T) {
+	// Mock system info
+	sysInfo := &Info{
+		OS:    "linux",
+		Shell: "bash",
+	}
+
+	validator := NewEnvironmentValidator(sysInfo)
+
+	testCases := []struct {
+		name           string
+		command        string
+		shouldError    bool
+		expectedReason string
+	}{
+		// Source commands
+		{
+			name:           "source bashrc",
+			command:        "source ~/.bashrc",
+			shouldError:    true,
+			expectedReason: "source",
+		},
+		{
+			name:           "dot source command",
+			command:        ". /etc/environment",
+			shouldError:    true,
+			expectedReason: "source",
+		},
+		{
+			name:           "source with sudo",
+			command:        "sudo source ~/.zshrc",
+			shouldError:    true,
+			expectedReason: "source",
+		},
+
+		// Export commands
+		{
+			name:           "export variable",
+			command:        "export PATH=$PATH:/usr/local/bin",
+			shouldError:    true,
+			expectedReason: "export",
+		},
+		{
+			name:           "variable assignment",
+			command:        "JAVA_HOME=/usr/lib/jvm/java-11",
+			shouldError:    true,
+			expectedReason: "export",
+		},
+		{
+			name:           "path modification",
+			command:        "echo 'export PATH=$PATH:/new/path' >> ~/.bashrc",
+			shouldError:    true,
+			expectedReason: "path_modification",
+		},
+
+		// CD commands
+		{
+			name:           "change directory",
+			command:        "cd /home/user/projects",
+			shouldError:    true,
+			expectedReason: "cd",
+		},
+		{
+			name:           "pushd command",
+			command:        "pushd /tmp",
+			shouldError:    true,
+			expectedReason: "cd",
+		},
+
+		// Virtual environment commands
+		{
+			name:           "activate virtualenv",
+			command:        "source venv/bin/activate",
+			shouldError:    true,
+			expectedReason: "source", // Will be caught by source detector
+		},
+		{
+			name:           "conda activate",
+			command:        "conda activate myenv",
+			shouldError:    true,
+			expectedReason: "conda_env",
+		},
+		{
+			name:           "poetry shell",
+			command:        "poetry shell",
+			shouldError:    true,
+			expectedReason: "virtual_env",
+		},
+		{
+			name:           "pipenv shell",
+			command:        "pipenv shell",
+			shouldError:    true,
+			expectedReason: "virtual_env",
+		},
+
+		// Version managers
+		{
+			name:           "nvm use",
+			command:        "nvm use 16",
+			shouldError:    true,
+			expectedReason: "rbenv_pyenv",
+		},
+		{
+			name:           "rbenv shell",
+			command:        "rbenv shell 3.0.0",
+			shouldError:    true,
+			expectedReason: "rbenv_pyenv",
+		},
+		{
+			name:           "pyenv local",
+			command:        "pyenv local 3.9.0",
+			shouldError:    true,
+			expectedReason: "rbenv_pyenv",
+		},
+
+		// Alias commands
+		{
+			name:           "create alias",
+			command:        "alias ll='ls -la'",
+			shouldError:    true,
+			expectedReason: "alias",
+		},
+		{
+			name:           "remove alias",
+			command:        "unalias ll",
+			shouldError:    true,
+			expectedReason: "alias",
+		},
+
+		// Shell options
+		{
+			name:           "set option",
+			command:        "set -e",
+			shouldError:    true,
+			expectedReason: "shell_options",
+		},
+		{
+			name:           "shell option",
+			command:        "shopt -s histappend",
+			shouldError:    true,
+			expectedReason: "shell_options",
+		},
+		{
+			name:           "ulimit",
+			command:        "ulimit -n 4096",
+			shouldError:    true,
+			expectedReason: "shell_options",
+		},
+
+		// Function definitions
+		{
+			name:           "function definition",
+			command:        "function myFunc() { echo 'hello'; }",
+			shouldError:    true,
+			expectedReason: "shell_function",
+		},
+		{
+			name:           "unset variable",
+			command:        "unset JAVA_HOME",
+			shouldError:    true,
+			expectedReason: "shell_function",
+		},
+
+		// Docker environment
+		{
+			name:           "docker machine env",
+			command:        "eval $(docker-machine env default)",
+			shouldError:    true,
+			expectedReason: "docker_env",
+		},
+		{
+			name:           "aws ecr login",
+			command:        "eval $(aws ecr get-login --no-include-email)",
+			shouldError:    true,
+			expectedReason: "docker_env",
+		},
+
+		// Environment modules
+		{
+			name:           "module load",
+			command:        "module load gcc/9.2.0",
+			shouldError:    true,
+			expectedReason: "environment_module",
+		},
+		{
+			name:           "ml command",
+			command:        "ml python/3.8",
+			shouldError:    true,
+			expectedReason: "environment_module",
+		},
+
+		// Commands that should NOT error
+		{
+			name:        "list files",
+			command:     "ls -la",
+			shouldError: false,
+		},
+		{
+			name:        "install package",
+			command:     "sudo apt-get install vim",
+			shouldError: false,
+		},
+		{
+			name:        "copy files",
+			command:     "cp file1.txt file2.txt",
+			shouldError: false,
+		},
+		{
+			name:        "create directory",
+			command:     "mkdir -p /tmp/test",
+			shouldError: false,
+		},
+		{
+			name:        "grep search",
+			command:     "grep -r 'pattern' /var/log/",
+			shouldError: false,
+		},
+		{
+			name:        "install then use tool",
+			command:     "sudo apt install unzip && unzip archive.zip",
+			shouldError: false,
+		},
+		{
+			name:        "pip install",
+			command:     "pip install requests",
+			shouldError: false,
+		},
+		{
+			name:        "echo command",
+			command:     "echo 'Hello World'",
+			shouldError: false,
+		},
+		{
+			name:        "systemctl command",
+			command:     "sudo systemctl restart nginx",
+			shouldError: false,
+		},
+		{
+			name:        "docker run",
+			command:     "docker run -it ubuntu:latest bash",
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator.ValidateEnvironmentCommand(tc.command)
+
+			if tc.shouldError {
+				if err == nil {
+					t.Errorf("Expected error for command '%s', but got none", tc.command)
+					return
+				}
+
+				envErr, ok := err.(*EnvironmentCommandError)
+				if !ok {
+					t.Errorf("Expected EnvironmentCommandError, got %T", err)
+					return
+				}
+
+				if tc.expectedReason != "" && envErr.Reason != tc.expectedReason {
+					t.Errorf("Expected reason '%s', got '%s' for command '%s'",
+						tc.expectedReason, envErr.Reason, tc.command)
+				}
+
+				// Test that the knightly message is generated
+				msg := envErr.GetKnightlyMessage()
+				if msg == "" {
+					t.Errorf("Expected non-empty knightly message for command '%s'", tc.command)
+				}
+
+				// Check that the original command is included in the message
+				if !strings.Contains(msg, tc.command) {
+					t.Errorf("Expected knightly message to contain original command '%s'", tc.command)
+				}
+
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error for command '%s', but got: %v", tc.command, err)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractCoreCommand(t *testing.T) {
+	validator := NewEnvironmentValidator(&Info{})
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple command",
+			input:    "ls -la",
+			expected: "ls -la",
+		},
+		{
+			name:     "sudo command",
+			input:    "sudo source ~/.bashrc",
+			expected: "source ~/.bashrc",
+		},
+		{
+			name:     "command chain with install",
+			input:    "sudo apt install curl && source ~/.bashrc",
+			expected: "source ~/.bashrc",
+		},
+		{
+			name:     "command with pipes",
+			input:    "export PATH=$PATH:/usr/local/bin",
+			expected: "export PATH=$PATH:/usr/local/bin",
+		},
+		{
+			name:     "complex chain",
+			input:    "sudo apt update && sudo apt install -y nodejs && source ~/.nvm/nvm.sh",
+			expected: "source ~/.nvm/nvm.sh",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := validator.extractCoreCommand(strings.ToLower(tc.input))
+			if result != strings.ToLower(tc.expected) {
+				t.Errorf("Expected '%s', got '%s'", strings.ToLower(tc.expected), result)
+			}
+		})
+	}
+}
+
+// Benchmark test for performance
+func BenchmarkValidateEnvironmentCommand(b *testing.B) {
+	validator := NewEnvironmentValidator(&Info{OS: "linux", Shell: "bash"})
+	commands := []string{
+		"ls -la",
+		"source ~/.bashrc",
+		"export PATH=$PATH:/usr/local/bin",
+		"sudo apt install vim",
+		"cd /home/user",
+		"conda activate myenv",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, cmd := range commands {
+			validator.ValidateEnvironmentCommand(cmd)
+		}
+	}
+}

--- a/internal/system/env_validator_test.go
+++ b/internal/system/env_validator_test.go
@@ -60,6 +60,12 @@ func TestEnvironmentValidator(t *testing.T) {
 			shouldError:    true,
 			expectedReason: "path_modification",
 		},
+		{
+			name:           "export with sudo",
+			command:        "which python && export PYTHON_ENV=$(which python)",
+			shouldError:    true,
+			expectedReason: "export",
+		},
 
 		// CD commands
 		{

--- a/internal/system/executor.go
+++ b/internal/system/executor.go
@@ -26,8 +26,6 @@ func (e *Executor) Execute(command string) error {
 	fmt.Printf("🗡️  Executing thy will, my lord: %s\n", command)
 	fmt.Println("═══════════════════════════════════════════════════════")
 
-	// For commands that need full terminal emulation, we can use a pseudo-terminal
-	// This requires the golang.org/x/term package
 	cmd := exec.Command(shell, "-c", command)
 
 	// Direct I/O connection - simplest and most compatible approach


### PR DESCRIPTION
This PR introduces a new environment validation system to prevent commands that modify the shell environment from being executed within a subshell where they would have no lasting effect.

**Key Changes:**

- **`internal/system/env_validator.go`**:
    - Adds `EnvironmentValidator` to detect commands like `source`, `export`, `cd`, virtual environment activations (`conda activate`, `poetry shell`), and version manager commands (`nvm use`, `rbenv shell`).
    - Implements `detectEnvironmentCommand` to categorize environment-affecting commands.
    - Includes helper functions like `extractCoreCommand` and `isInstallCommand` to intelligently parse commands.
    - Defines `EnvironmentCommandError` to provide user-friendly messages for such commands, guiding users to execute them directly in their shell.
- **`internal/system/env_validator_test.go`**:
    - Adds comprehensive unit tests for `EnvironmentValidator` covering various scenarios, including source commands, export commands, `cd`, virtual environment tools, version managers, aliases, shell options, function definitions, Docker environment commands, and environment modules.
    - Includes a benchmark test for performance evaluation.
- **`internal/cli/root.go`**:
    - Integrates the `EnvironmentValidator` into the command execution flow.
    - If an environment-affecting command is detected, it will now display a "Knightly Message" explaining why the command cannot be run and provides the command for the user to execute directly.
- **`internal/system/executor.go`**:
    - Removes a comment related to pseudo-terminal usage, as the new validation handles environment-affecting commands differently.

This enhancement improves the user experience by providing clear feedback when a command that modifies the shell environment is attempted, ensuring users understand why it cannot be executed by the application and how to achieve their desired outcome.