### PR TITLE
feat: Implement OpenAI and Anthropic provider integrations

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -2,12 +2,16 @@
 package ai
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/minand-mohan/execute-my-will/internal/config"
 )
 
-// Anthropic Provider (placeholder)
+// Anthropic Provider
 type AnthropicProvider struct {
 	apiKey      string
 	model       string
@@ -15,7 +19,38 @@ type AnthropicProvider struct {
 	temperature float32
 }
 
+type AnthropicRequest struct {
+	Model       string             `json:"model"`
+	MaxTokens   int                `json:"max_tokens"`
+	Temperature float32            `json:"temperature"`
+	Messages    []AnthropicMessage `json:"messages"`
+}
+
+type AnthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type AnthropicResponse struct {
+	Content []AnthropicContent `json:"content"`
+	Error   *AnthropicError    `json:"error,omitempty"`
+}
+
+type AnthropicContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type AnthropicError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
 func NewAnthropicProvider(cfg *config.Config) (*AnthropicProvider, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("anthropic API key is required")
+	}
+
 	return &AnthropicProvider{
 		apiKey:      cfg.APIKey,
 		model:       cfg.Model,
@@ -25,6 +60,79 @@ func NewAnthropicProvider(cfg *config.Config) (*AnthropicProvider, error) {
 }
 
 func (a *AnthropicProvider) GenerateResponse(prompt string) (string, error) {
-	// Implementation for Anthropic API
-	return "", fmt.Errorf("anthropic provider not yet implemented")
+	url := "https://api.anthropic.com/v1/messages"
+
+	request := AnthropicRequest{
+		Model:       a.model,
+		MaxTokens:   a.maxTokens,
+		Temperature: a.temperature,
+		Messages: []AnthropicMessage{
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", a.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var response AnthropicResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Check for API errors
+	if response.Error != nil {
+		return "", fmt.Errorf("anthropic API error: %s", response.Error.Message)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if len(response.Content) == 0 {
+		return "", fmt.Errorf("no response generated")
+	}
+
+	responseText := response.Content[0].Text
+
+	// Handle failure cases as defined in the prompt
+	if responseText == "FAILURE: Intent too complex for a single shell command." {
+		return "", fmt.Errorf("intent too complex for a single shell command, might need merlin")
+	}
+
+	if responseText == "FAILURE: Directory reference too vague." {
+		return "", fmt.Errorf("directory reference too vague - please specify exact paths. the map instructions are not clear")
+	}
+
+	// Check for any other FAILURE responses
+	if len(responseText) >= 8 && responseText[:8] == "FAILURE:" {
+		return "", fmt.Errorf("command generation failed: %s", responseText[9:])
+	}
+
+	return responseText, nil
 }

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -1,12 +1,17 @@
+// File: internal/ai/openai.go
 package ai
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/minand-mohan/execute-my-will/internal/config"
 )
 
-// OpenAI Provider (placeholder)
+// OpenAI Provider
 type OpenAIProvider struct {
 	apiKey      string
 	model       string
@@ -14,7 +19,38 @@ type OpenAIProvider struct {
 	temperature float32
 }
 
+type OpenAIRequest struct {
+	Model       string          `json:"model"`
+	Messages    []OpenAIMessage `json:"messages"`
+	MaxTokens   int             `json:"max_tokens"`
+	Temperature float32         `json:"temperature"`
+}
+
+type OpenAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type OpenAIResponse struct {
+	Choices []OpenAIChoice `json:"choices"`
+	Error   *OpenAIError   `json:"error,omitempty"`
+}
+
+type OpenAIChoice struct {
+	Message OpenAIMessage `json:"message"`
+}
+
+type OpenAIError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
+
 func NewOpenAIProvider(cfg *config.Config) (*OpenAIProvider, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("OpenAI API key is required")
+	}
+
 	return &OpenAIProvider{
 		apiKey:      cfg.APIKey,
 		model:       cfg.Model,
@@ -24,6 +60,78 @@ func NewOpenAIProvider(cfg *config.Config) (*OpenAIProvider, error) {
 }
 
 func (o *OpenAIProvider) GenerateResponse(prompt string) (string, error) {
-	// Implementation for OpenAI API
-	return "", fmt.Errorf("OpenAI provider not yet implemented")
+	url := "https://api.openai.com/v1/chat/completions"
+
+	request := OpenAIRequest{
+		Model: o.model,
+		Messages: []OpenAIMessage{
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+		MaxTokens:   o.maxTokens,
+		Temperature: o.temperature,
+	}
+
+	jsonData, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.apiKey))
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var response OpenAIResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// Check for API errors
+	if response.Error != nil {
+		return "", fmt.Errorf("OpenAI API error: %s", response.Error.Message)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if len(response.Choices) == 0 {
+		return "", fmt.Errorf("no response generated")
+	}
+
+	responseText := response.Choices[0].Message.Content
+
+	// Handle failure cases as defined in the prompt
+	if responseText == "FAILURE: Intent too complex for a single shell command." {
+		return "", fmt.Errorf("intent too complex for a single shell command, might need merlin")
+	}
+
+	if responseText == "FAILURE: Directory reference too vague." {
+		return "", fmt.Errorf("directory reference too vague - please specify exact paths. the map instructions are not clear")
+	}
+
+	// Check for any other FAILURE responses
+	if len(responseText) >= 8 && responseText[:8] == "FAILURE:" {
+		return "", fmt.Errorf("command generation failed: %s", responseText[9:])
+	}
+
+	return responseText, nil
 }


### PR DESCRIPTION
This commit introduces the implementation for OpenAI and Anthropic AI providers, enabling the application to generate responses using these services.

- Implemented the `GenerateResponse` method for both `OpenAIProvider` and `AnthropicProvider`.
- Added structs for request and response payloads for both providers.
- Included error handling for API requests, response parsing, and specific failure cases defined in the prompt (e.g., intent too complex, vague directory references).
- Added API key validation during provider initialization.